### PR TITLE
2.8/normallabelwithoutorthogonaltype

### DIFF
--- a/src/main/java/edu/stanford/hakan/aim4api/compability/aimv3/Lexicon.java
+++ b/src/main/java/edu/stanford/hakan/aim4api/compability/aimv3/Lexicon.java
@@ -58,8 +58,8 @@ public class Lexicon extends HashMap<String, CD> {
 			//lexicon items that are used specificly by aimapi should be placed in the dictionary 
 			//this is used to achieve independence from epad-ws and db
 			this.put("G-D7FE", new CD("G-D7FE","Length","SRT"));
-			this.put("99EPADF272", new CD("99EPADF272","ShortAxis","99EPAD"));
-			this.put("99EPADF283", new CD("99EPADF283","LongAxis","99EPAD"));
+			this.put("G-A186", new CD("G-A186","ShortAxis","SRT"));
+			this.put("G-A185", new CD("G-A185","LongAxis","SRT"));
 			
 			this.put("RID12780", new CD("RID12780","Calculation","RadLex","3.2"));
 			//update with Andrey's list

--- a/src/main/java/edu/stanford/hakan/aim4api/project/epad/Aim.java
+++ b/src/main/java/edu/stanford/hakan/aim4api/project/epad/Aim.java
@@ -1930,37 +1930,40 @@ public class Aim extends ImageAnnotation implements Aimapi, Serializable {
     }
     
     public void addLongAxisMeanCalculation(double value, Integer shapeId, String units) {
-    	addCalculation(value,shapeId,units,LONG_AXIS+"_"+MEAN, "R-00317");
+    	addCalculation(value,shapeId,units,LONG_AXIS+"_"+MEAN, "R-00317", MEAN);
     }
     public void addLongAxisStdDevCalculation(double value, Integer shapeId, String units) {
-    	addCalculation(value,shapeId,units,LONG_AXIS+"_"+STD_DEV, "R-10047");
+    	addCalculation(value,shapeId,units,LONG_AXIS+"_"+STD_DEV, "R-10047", STD_DEV);
     }
     public void addLongAxisMinCalculation(double value, Integer shapeId, String units) {
-    	addCalculation(value,shapeId,units,LONG_AXIS+"_"+MIN, "R-404FB");
+    	addCalculation(value,shapeId,units,LONG_AXIS+"_"+MIN, "R-404FB", MIN);
     }
     public void addLongAxisMaxCalculation(double value, Integer shapeId, String units) {
-    	addCalculation(value,shapeId,units,LONG_AXIS+"_"+MAX, "G-A437");
+    	addCalculation(value,shapeId,units,LONG_AXIS+"_"+MAX, "G-A437", MAX);
     }
     
     public void addShortAxisMeanCalculation(double value, Integer shapeId, String units) {
-    	addCalculation(value,shapeId,units,SHORT_AXIS+"_"+MEAN, "R-00317");
+    	addCalculation(value,shapeId,units,SHORT_AXIS+"_"+MEAN, "R-00317", MEAN);
     }
     public void addShortAxisStdDevCalculation(double value, Integer shapeId, String units) {
-    	addCalculation(value,shapeId,units,SHORT_AXIS+"_"+STD_DEV, "R-10047");
+    	addCalculation(value,shapeId,units,SHORT_AXIS+"_"+STD_DEV, "R-10047", STD_DEV);
     }
     public void addShortAxisMinCalculation(double value, Integer shapeId, String units) {
-    	addCalculation(value,shapeId,units,SHORT_AXIS+"_"+MIN, "R-404FB");
+    	addCalculation(value,shapeId,units,SHORT_AXIS+"_"+MIN, "R-404FB", MIN);
     }
     public void addShortAxisMaxCalculation(double value, Integer shapeId, String units) {
-    	addCalculation(value,shapeId,units,SHORT_AXIS+"_"+MAX, "G-A437");
+    	addCalculation(value,shapeId,units,SHORT_AXIS+"_"+MAX, "G-A437", MAX);
     }
     
     public void addLengthCalculation(double value, Integer shapeId) {
     	addCalculation(value,shapeId,LINE_MEASURE,LINE_LENGTH, "G-D7FE");
     }
     
-    
+
     public void addCalculation(double value, Integer shapeId, String units, String name, String code) {
+    	addCalculation(value, shapeId, units, name, code, null);
+    }
+    public void addCalculation(double value, Integer shapeId, String units, String name, String code, String algorithmName) {
 
     	//rdf references needs to be fixed for shapeid to work
 //    	//if it is there set it if not add it
@@ -1973,7 +1976,10 @@ public class Aim extends ImageAnnotation implements Aimapi, Serializable {
         Calculation calculation = new Calculation();
         calculation.setCagridId(0);
         calculation.setAlgorithmVersion(VERSION);
-        calculation.setAlgorithmName(name);
+        if (algorithmName==null)
+        	calculation.setAlgorithmName(name);
+        else
+        	calculation.setAlgorithmName(algorithmName);
         //ml value in Lexicon
         calculation.setAlgorithmType("RID12780");
         

--- a/src/main/java/edu/stanford/hakan/aim4api/project/epad/Aim.java
+++ b/src/main/java/edu/stanford/hakan/aim4api/project/epad/Aim.java
@@ -1916,10 +1916,10 @@ public class Aim extends ImageAnnotation implements Aimapi, Serializable {
     	addCalculation(value,shapeId,units,MAX, "G-A437");
     }
     public void addLongAxisCalculation(double value, Integer shapeId, String units) {
-    	addCalculation(value,shapeId,units,LONG_AXIS, "99EPADF283");
+    	addCalculation(value,shapeId,units,LONG_AXIS, "G-A185");
     }
     public void addShortAxisCalculation(double value, Integer shapeId, String units) {
-    	addCalculation(value,shapeId,units,SHORT_AXIS, "99EPADF272");
+    	addCalculation(value,shapeId,units,SHORT_AXIS, "G-A186");
     }
     //get the unit from line_measure constant
     public void addLongAxisCalculation(double value, Integer shapeId) {

--- a/src/main/java/edu/stanford/hakan/aim4api/project/epad/Aim.java
+++ b/src/main/java/edu/stanford/hakan/aim4api/project/epad/Aim.java
@@ -1861,7 +1861,7 @@ public class Aim extends ImageAnnotation implements Aimapi, Serializable {
         CalculationResult calculationResult = new CalculationResult();
         calculationResult.setCagridId(0);
         calculationResult.setType(CalculationResultIdentifier.Scalar);
-        calculationResult.setUnitOfMeasure(LINE_MEASURE);
+        calculationResult.setUnitOfMeasure(Aim.getUCUMUnit(LINE_MEASURE));
         calculationResult.setNumberOfDimensions(0);
         //ml value in Lexicon
         calculationResult.setDataType("99EPADD1");
@@ -1895,6 +1895,16 @@ public class Aim extends ImageAnnotation implements Aimapi, Serializable {
         return calculation;
     }
     
+    public static String getUCUMUnit(String units){
+		if (units==null) 
+			return "";
+		if (units.equalsIgnoreCase("HU")) {
+			return "[hnsf'U]";
+		}else if (units.equalsIgnoreCase("SUV")) {
+			return "{SUVbw}g/ml";
+		}
+		return units;
+    }
     /**
      * add mean calculation to the annonation
      * @param mean
@@ -1923,10 +1933,10 @@ public class Aim extends ImageAnnotation implements Aimapi, Serializable {
     }
     //get the unit from line_measure constant
     public void addLongAxisCalculation(double value, Integer shapeId) {
-    	addCalculation(value,shapeId,LINE_MEASURE,LONG_AXIS, "99EPADF283");
+    	addCalculation(value,shapeId,LINE_MEASURE,LONG_AXIS, "G-A185");
     }
     public void addShortAxisCalculation(double value, Integer shapeId) {
-    	addCalculation(value,shapeId,LINE_MEASURE,SHORT_AXIS, "99EPADF272");
+    	addCalculation(value,shapeId,LINE_MEASURE,SHORT_AXIS, "G-A186");
     }
     
     public void addLongAxisMeanCalculation(double value, Integer shapeId, String units) {
@@ -2003,7 +2013,7 @@ public class Aim extends ImageAnnotation implements Aimapi, Serializable {
         CalculationResult calculationResult = new CalculationResult();
         calculationResult.setCagridId(0);
         calculationResult.setType(CalculationResultIdentifier.Scalar);
-        calculationResult.setUnitOfMeasure(units);
+        calculationResult.setUnitOfMeasure(Aim.getUCUMUnit(units));
        
         calculationResult.setNumberOfDimensions(0);
         //ml value in Lexicon

--- a/src/main/java/edu/stanford/hakan/aim4api/project/epad/Aim.java
+++ b/src/main/java/edu/stanford/hakan/aim4api/project/epad/Aim.java
@@ -349,42 +349,43 @@ public class Aim extends ImageAnnotation implements Aimapi, Serializable {
 
             shape.setIncludeFlag(true);
 
-            //ml add calculation only if it is a line
-            if (shapeType==ShapeType.LINE) {
-            	addCalculation(addlengthCalculation(
-                    coords,
-                    calculateLineLength(getCoords(shape), pixelSpacingX,
-                            pixelSpacingY), shape.getShapeIdentifier()));
-            }
-            else if (shapeType==ShapeType.NORMAL) {
-            	logger.info("ellipse");
-            	//first line long axis
-            	List<TwoDCoordinate> coordslist = new ArrayList<TwoDCoordinate>();
-            	coordslist.add(coords.get(0));
-            	coordslist.add(coords.get(1));
-            	double length1 = calculateLineLength(coordslist, pixelSpacingX,
-    					pixelSpacingY);
-            	logger.info("line length 1 : " + length1);
-            	
-            	
-            	coordslist.clear();
-            	coordslist.add(coords.get(2));
-            	coordslist.add(coords.get(3));
-            	double length2 = calculateLineLength(coordslist, pixelSpacingX,
-    					pixelSpacingY);
-            	logger.info("line length 2: " + length2);
-            	if (length1>=length2){
-            		addLongAxisCalculation(
-            			length1, shape.getShapeIdentifier(),LINE_MEASURE);
-            		addShortAxisCalculation( 
-            			length2, shape.getShapeIdentifier(),LINE_MEASURE);
-            	}else {
-            		addLongAxisCalculation(
-                			length2, shape.getShapeIdentifier(),LINE_MEASURE);
-                	addShortAxisCalculation( 
-                			length1, shape.getShapeIdentifier(),LINE_MEASURE);
-            	}
-            }
+            //ui will add the length calculations
+//            //ml add calculation only if it is a line
+//            if (shapeType==ShapeType.LINE) {
+//            	addCalculation(addlengthCalculation(
+//                    coords,
+//                    calculateLineLength(getCoords(shape), pixelSpacingX,
+//                            pixelSpacingY), shape.getShapeIdentifier()));
+//            }
+//            else if (shapeType==ShapeType.NORMAL) {
+//            	logger.info("ellipse");
+//            	//first line long axis
+//            	List<TwoDCoordinate> coordslist = new ArrayList<TwoDCoordinate>();
+//            	coordslist.add(coords.get(0));
+//            	coordslist.add(coords.get(1));
+//            	double length1 = calculateLineLength(coordslist, pixelSpacingX,
+//    					pixelSpacingY);
+//            	logger.info("line length 1 : " + length1);
+//            	
+//            	
+//            	coordslist.clear();
+//            	coordslist.add(coords.get(2));
+//            	coordslist.add(coords.get(3));
+//            	double length2 = calculateLineLength(coordslist, pixelSpacingX,
+//    					pixelSpacingY);
+//            	logger.info("line length 2: " + length2);
+//            	if (length1>=length2){
+//            		addLongAxisCalculation(
+//            			length1, shape.getShapeIdentifier(),LINE_MEASURE);
+//            		addShortAxisCalculation( 
+//            			length2, shape.getShapeIdentifier(),LINE_MEASURE);
+//            	}else {
+//            		addLongAxisCalculation(
+//                			length2, shape.getShapeIdentifier(),LINE_MEASURE);
+//                	addShortAxisCalculation( 
+//                			length1, shape.getShapeIdentifier(),LINE_MEASURE);
+//            	}
+//            }
 
             addGeometricShape(shape);
         }
@@ -406,6 +407,7 @@ public class Aim extends ImageAnnotation implements Aimapi, Serializable {
     public void setNormalLineLengths(int shapeID, List<TwoDCoordinate> coords,
     		double pixelSpacingX, double pixelSpacingY) {
     	
+    	logger.warning("Depreceated. Save the normal line calculations with addLongAxisCalculation and addShortAxisCalculation");
     	//find the line lengths first
     	List<TwoDCoordinate> coordslist = new ArrayList<TwoDCoordinate>();
     	coordslist.add(coords.get(0));
@@ -846,7 +848,7 @@ public class Aim extends ImageAnnotation implements Aimapi, Serializable {
     public boolean isEllipse(int shapeID) {
         return getShapeType(shapeID).equals(ShapeType.ELLIPSE);
     }
-
+    
     @Override
     public boolean isSpline(int shapeID) {
         return getShapeType(shapeID).equals(ShapeType.SPLINE);
@@ -1919,12 +1921,53 @@ public class Aim extends ImageAnnotation implements Aimapi, Serializable {
     public void addShortAxisCalculation(double value, Integer shapeId, String units) {
     	addCalculation(value,shapeId,units,SHORT_AXIS, "99EPADF272");
     }
-        
+    //get the unit from line_measure constant
+    public void addLongAxisCalculation(double value, Integer shapeId) {
+    	addCalculation(value,shapeId,LINE_MEASURE,LONG_AXIS, "99EPADF283");
+    }
+    public void addShortAxisCalculation(double value, Integer shapeId) {
+    	addCalculation(value,shapeId,LINE_MEASURE,SHORT_AXIS, "99EPADF272");
+    }
+    
+    public void addLongAxisMeanCalculation(double value, Integer shapeId, String units) {
+    	addCalculation(value,shapeId,units,LONG_AXIS+"_"+MEAN, "R-00317");
+    }
+    public void addLongAxisStdDevCalculation(double value, Integer shapeId, String units) {
+    	addCalculation(value,shapeId,units,LONG_AXIS+"_"+STD_DEV, "R-10047");
+    }
+    public void addLongAxisMinCalculation(double value, Integer shapeId, String units) {
+    	addCalculation(value,shapeId,units,LONG_AXIS+"_"+MIN, "R-404FB");
+    }
+    public void addLongAxisMaxCalculation(double value, Integer shapeId, String units) {
+    	addCalculation(value,shapeId,units,LONG_AXIS+"_"+MAX, "G-A437");
+    }
+    
+    public void addShortAxisMeanCalculation(double value, Integer shapeId, String units) {
+    	addCalculation(value,shapeId,units,SHORT_AXIS+"_"+MEAN, "R-00317");
+    }
+    public void addShortAxisStdDevCalculation(double value, Integer shapeId, String units) {
+    	addCalculation(value,shapeId,units,SHORT_AXIS+"_"+STD_DEV, "R-10047");
+    }
+    public void addShortAxisMinCalculation(double value, Integer shapeId, String units) {
+    	addCalculation(value,shapeId,units,SHORT_AXIS+"_"+MIN, "R-404FB");
+    }
+    public void addShortAxisMaxCalculation(double value, Integer shapeId, String units) {
+    	addCalculation(value,shapeId,units,SHORT_AXIS+"_"+MAX, "G-A437");
+    }
+    
+    public void addLengthCalculation(double value, Integer shapeId) {
+    	addCalculation(value,shapeId,LINE_MEASURE,LINE_LENGTH, "G-D7FE");
+    }
+    
+    
     public void addCalculation(double value, Integer shapeId, String units, String name, String code) {
 
-    	//if it is there set it if not add it
-    	if (shapeId!=null && setShapeCalculation(shapeId, name, value))
-    		return;
+    	//rdf references needs to be fixed for shapeid to work
+//    	//if it is there set it if not add it
+//    	if (shapeId!=null && setShapeCalculation(shapeId, name, value)){
+//    		logger.info("set the calculation instead of adding new");
+//    		return;
+//    	}
     	
         // Create a Calculation instance
         Calculation calculation = new Calculation();
@@ -1955,6 +1998,7 @@ public class Aim extends ImageAnnotation implements Aimapi, Serializable {
         calculationResult.setCagridId(0);
         calculationResult.setType(CalculationResultIdentifier.Scalar);
         calculationResult.setUnitOfMeasure(units);
+       
         calculationResult.setNumberOfDimensions(0);
         //ml value in Lexicon
         calculationResult.setDataType("99EPADD1");

--- a/src/main/java/edu/stanford/hakan/aim4api/usage/AnnotationExtender.java
+++ b/src/main/java/edu/stanford/hakan/aim4api/usage/AnnotationExtender.java
@@ -14,6 +14,7 @@ import edu.stanford.hakan.aim4api.compability.aimv3.CalculationData;
 import edu.stanford.hakan.aim4api.compability.aimv3.CalculationResult;
 import edu.stanford.hakan.aim4api.compability.aimv3.Dimension;
 import edu.stanford.hakan.aim4api.compability.aimv3.ImageAnnotation;
+import edu.stanford.hakan.aim4api.project.epad.Aim;
 
 /**
  *
@@ -202,7 +203,7 @@ public class AnnotationExtender {
     	calculation.setAlgorithmVersion(parentCD.getCodeSystemVersion());
     	calculation.setAlgorithmType(parentCD.getCode()); 
     	calculation.setAlgorithmName(parentCD.getDisplayName().getValue());
-    	calculation.setUid("0");
+//    	calculation.setUid("0");
     	
     	
     	if (feature!=null) {
@@ -224,7 +225,7 @@ public class AnnotationExtender {
         calculationResult.setType(CalculationResultIdentifier.Scalar);
         if (unit==null)
         	unit="ratio";
-        calculationResult.setUnitOfMeasure(unit);
+        calculationResult.setUnitOfMeasure(Aim.getUCUMUnit(unit));
         //ml double
         calculationResult.setDataType("99EPADD1");;
         calculationResult.setNumberOfDimensions(1);


### PR DESCRIPTION
longaxis and shortaxis lexicon entities replaced with the ones from SRT
added longaxis mean, min, max, std dev and shortaxis mean, min, max, std dev
removed the setshapecalculation
extended addCalculation to enable different algorithm name when algorithm name is sent as a parameter and used mean as the algorithm name of the calculation longaxis mean
units converted to UCUM units
removed the calculation uid resetting codes